### PR TITLE
Adding excludeStrategies search query

### DIFF
--- a/src/app/services/puzzle.service.ts
+++ b/src/app/services/puzzle.service.ts
@@ -126,6 +126,12 @@ function filterInputQuery(puzzles){
             filterValues.push({ 'strategies': { $in : puzzles['strategies'] } });
             delete puzzles.strategies;
         }
+        // we want to find all puzzles that do not contain the strategies in the strategyArray
+        if ('excludeStrategies' in puzzles){
+            filterValues.push({ 'strategies': { $nin : puzzles['excludeStrategies'] } });
+            delete puzzles.excludeStrategies;
+        }
+
         // we want to find all puzzles that contain the drillStrategies in the drillStrategyArray
         if ('drillStrategies' in puzzles){
             filterValues.push({ 'drillStrategies': { $in : puzzles['drillStrategies'] } });

--- a/src/app/validationAndSanitation/puzzle.validationAndSanitation.ts
+++ b/src/app/validationAndSanitation/puzzle.validationAndSanitation.ts
@@ -70,6 +70,12 @@ exports.validatePuzzleParameters = [
             "HIDDEN_QUINTUPLET", "HIDDEN_SEXTUPLET", "HIDDEN_SEPTUPLET", "HIDDEN_OCTUPLET", "POINTING_PAIR", "POINTING_TRIPLET",
             "BOX_LINE_REDUCTION", "X_WING", "SWORDFISH", "SINGLES_CHAINING"]),
 
+    query('excludeStrategies', 'Exclude strategy array is not valid').optional().isArray().isIn(
+        ["NAKED_SINGLE", "HIDDEN_SINGLE", "NAKED_PAIR", "NAKED_TRIPLET", "NAKED_QUADRUPLET", "NAKED_QUINTUPLET",
+            "NAKED_SEXTUPLET", "NAKED_SEPTUPLET", "NAKED_OCTUPLET", "HIDDEN_PAIR", "HIDDEN_TRIPLET", "HIDDEN_QUADRUPLET",
+            "HIDDEN_QUINTUPLET", "HIDDEN_SEXTUPLET", "HIDDEN_SEPTUPLET", "HIDDEN_OCTUPLET", "POINTING_PAIR", "POINTING_TRIPLET",
+            "BOX_LINE_REDUCTION", "X_WING", "SWORDFISH", "SINGLES_CHAINING"]),
+
     query('difficulty', "difficulty is not an integer or is not in correct range").optional().isInt({ min: 0, max: 1000 }),
     query('fastestSolveTime', 'fastest solve time is not an integer').optional().isInt(),
     query('averageSolveTime', 'average solve time is not an integer').optional().isInt(),


### PR DESCRIPTION
Changelog:
- Added ability to search for puzzles that do not have strategies in the provided array using "excludeStrategies"